### PR TITLE
rename featherlight-prev to featherlight-previous

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -43,11 +43,11 @@
 					background: #000;
 				}
 				.featherlight-gallery2 .featherlight-next:hover,
-				.featherlight-gallery2 .featherlight-prev:hover {
+				.featherlight-gallery2 .featherlight-previous:hover {
 					background: rgba(0,0,0,0.5);
 				}
 				.featherlight-gallery2 .featherlight-next:hover span,
-				.featherlight-gallery2 .featherlight-prev:hover span {
+				.featherlight-gallery2 .featherlight-previous:hover span {
 					font-size: 25px;
 					line-height: 25px;
 					margin-top: -12.5px;

--- a/src/featherlight.gallery.css
+++ b/src/featherlight.gallery.css
@@ -7,7 +7,7 @@
 **/
 @media all {
 	.featherlight-next,
-	.featherlight-prev {
+	.featherlight-previous {
 		display: block;
 		position: absolute;
 		top: 0; bottom: 0;
@@ -23,19 +23,19 @@
 		user-select: none;
 	}
 
-	.featherlight-prev {
+	.featherlight-previous {
 		left: 0;
 		right: 80%;
 	}
 
 	.featherlight-next:hover,
-	.featherlight-prev:hover {
+	.featherlight-previous:hover {
 		background: rgba(255,255,255,0.25);
 	}
 
 
 	.featherlight-next span,
-	.featherlight-prev span {
+	.featherlight-previous span {
 		display: none;
 		position: absolute;
 
@@ -61,7 +61,7 @@
 
 
 	.featherlight-next:hover span,
-	.featherlight-prev:hover span {
+	.featherlight-previous:hover span {
 		display: inline-block;
 	}
 }

--- a/src/featherlight.gallery.js
+++ b/src/featherlight.gallery.js
@@ -51,7 +51,7 @@
 								}
 								loadNext($nx);
 							}),
-							$prev = $('<em title="previous" class="'+fl.config.namespace+'-prev"><span>'+fl.config.gallery.previous+'</span></em>').click(function(){
+							$prev = $('<em title="previous" class="'+fl.config.namespace+'-previous"><span>'+fl.config.gallery.previous+'</span></em>').click(function(){
 								var $nx = $gallery.eq($gallery.index(fl.$elm)-1);
 								if($nx.length < 1){
 									$nx = $gallery.last();

--- a/src/gallery.html
+++ b/src/gallery.html
@@ -43,11 +43,11 @@
 					background: #000;
 				}
 				.featherlight-gallery2 .featherlight-next:hover,
-				.featherlight-gallery2 .featherlight-prev:hover {
+				.featherlight-gallery2 .featherlight-previous:hover {
 					background: rgba(0,0,0,0.5);
 				}
 				.featherlight-gallery2 .featherlight-next:hover span,
-				.featherlight-gallery2 .featherlight-prev:hover span {
+				.featherlight-gallery2 .featherlight-previous:hover span {
 					font-size: 25px;
 					line-height: 25px;
 					margin-top: -12.5px;


### PR DESCRIPTION
The class names are part of the API. As such, isn't it best to be consistent and avoid abbreviations? There's `config.previous` but `featherlight-prev`...

This commit renames the class `featherlight-prev` to `featherlight-previous`
