### PR TITLE
Added config.closeOnAny click anywhere to close

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Featherlight comes with a bunch of configuration-options which make it very flex
 		closeSpeed:   250,                    /* Duration of closing animation */
 		closeOnBg:    true,                   /* Close lightbox on click on the background */
 		closeOnEsc:   true,                   /* Close lightbox when pressing esc */
+		closeOnAny:   false,                  /* Close lightbox when clicking anywhere */
 		closeIcon:    '&#10005;',             /* Close icon */
 		beforeOpen:   null,                   /* Called before open. can return false to prevent opening of lightbox. Gets event as parameter, this contains all data */
 		beforeClose:  null,                   /* Called before close. can return false to prevent opening of lightbox. Gets event as parameter, this contains all data */
@@ -177,6 +178,11 @@ If true, the close event is also bound to the background
 
 	closeOnEsc – Boolean: true
 If true, the lightbox is closed when pressing the ESC key
+
+================================================
+
+	closeOnAny – Boolean: false
+If true, the close event will succeed when clicking anywhere
 
 ================================================
 

--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -31,6 +31,7 @@
 			closeSpeed:   250,                    /* Duration of closing animation */
 			closeOnBg:    true,                   /* Close lightbox on click on the background */
 			closeOnEsc:   true,                   /* Close lightbox when pressing esc */
+			closeOnAny:   false,                  /* Close lightbox when clicking anywhere */
 			closeIcon:    '&#10005;',             /* Close icon */
 			beforeOpen:   null,                   /* Called before open. can return false to prevent opening of lightbox. Gets event as parameter, this contains all data */
 			beforeClose:  null,                   /* Called before close. can return false to prevent opening of lightbox. Gets event as parameter, this contains all data */
@@ -189,7 +190,7 @@
 					config = self.config,
 					$instance = $(event.target);
 
-				if((config.closeOnBg && $instance.is('.'+config.namespace)) || $instance.is('.'+config.namespace+'-close') ){
+				if(config.closeOnAny || (config.closeOnBg && $instance.is('.'+config.namespace)) || $instance.is('.'+config.namespace+'-close')){
 					if(event){
 						event.preventDefault();
 					}


### PR DESCRIPTION
Added config.closeOnAny to allow closing the lightbox by clicking anywhere.
Updated README.md to reflect the change.

Default behavior forces clicking on the background or close button, which can be overly restrictive -- especially when sizing the lightbox to cover most of the visible window.

Mucha Gracia
