### PR TITLE
Update featherlight.js

### DIFF
--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -82,7 +82,6 @@
 				var goOn = this.config.beforeClose.call(this, event);
 				if(false !== goOn){ /* if before function did not stop propagation */
 					this.close(event);
-					this.config.afterClose.call(this, event);
 				}
 			}
 		},
@@ -225,6 +224,7 @@
 				self.constructor._opened.remove(self._openedCallback);
 				self.$instance.fadeOut(self.config.closeSpeed,function(){
 					self.$instance.detach();
+					self.config.afterClose.call(this,event);
 				});
 			}
 		},


### PR DESCRIPTION
The `afterClose` callback is being called at the same time as the fadeOut animation begins.  Moved the call to `afterClose` to the fadeOut completion callback, thereby effectively moving the "event" to when the close is finished.
