### PR TITLE
Update RawGit URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Here you'll find a [list of all the changes](https://github.com/noelboss/feather
 
 All styling is done using CSS so you'll want to include the Featherlight CSS in your head.
 
-	<link href="//rawgithub.com/noelboss/featherlight/master/release/featherlight.min.css" type="text/css" rel="stylesheet" title="Featherlight Styles" />
+	<link href="//cdn.rawgit.com/noelboss/featherlight/master/release/featherlight.min.css" type="text/css" rel="stylesheet" title="Featherlight Styles" />
 
 Be aware that Featherlight uses very unspecific CSS selectors to help you overwrite every aspect. This means in turn, that if you're not following a modularized approach to write CSS (which you should! It's terrific!) and have many global and specific definitions (read ID's and such – which you shouldn't), these definitions can break the Featherlight styling.
 
 Featherlight requires jQuery version 1.7.0 or higher. It's recommended to include the javascript at the bottom of the page before the closing `</body>` tag.
 
 	<script src="//code.jquery.com/jquery-latest.js"></script>
-	<script src="//rawgithub.com/noelboss/featherlight/master/release/featherlight.min.js" type="text/javascript" charset="utf-8"></script>
+	<script src="//cdn.rawgit.com/noelboss/featherlight/master/release/featherlight.min.js" type="text/javascript" charset="utf-8"></script>
 
 
 # Usage
@@ -363,13 +363,13 @@ Instead of navigation buttons it will use swipe events on touch devices, assumin
 
 Simply include the extension CSS and JavaScript Files after the regular featherlight files like this:
 
-	<link href="//rawgithub.com/noelboss/featherlight/master/release/featherlight.min.css" type="text/css" rel="stylesheet" title="Featherlight Styles" />
-	<link href="//rawgithub.com/noelboss/featherlight/master/release/featherlight.gallery.min.css" type="text/css" rel="stylesheet" title="Featherlight Gallery Styles" />
+	<link href="//cdn.rawgit.com/noelboss/featherlight/master/release/featherlight.min.css" type="text/css" rel="stylesheet" title="Featherlight Styles" />
+	<link href="//cdn.rawgit.com/noelboss/featherlight/master/release/featherlight.gallery.min.css" type="text/css" rel="stylesheet" title="Featherlight Gallery Styles" />
 
 Add the JavaScript at the bottom of the body:
 
 	<script src="//code.jquery.com/jquery-latest.js"></script>
-	<script src="//rawgithub.com/noelboss/featherlight/master/release/featherlight.min.js" type="text/javascript" charset="utf-8"></script>
-	<script src="//rawgithub.com/noelboss/featherlight/master/release/featherlight.gallery.min.js" type="text/javascript" charset="utf-8"></script>
+	<script src="//cdn.rawgit.com/noelboss/featherlight/master/release/featherlight.min.js" type="text/javascript" charset="utf-8"></script>
+	<script src="//cdn.rawgit.com/noelboss/featherlight/master/release/featherlight.gallery.min.js" type="text/javascript" charset="utf-8"></script>
 
 Check out the example here: [Gallery with Featherlight](http://noelboss.github.io/featherlight/gallery.html)


### PR DESCRIPTION
1) Use the updated name, RawGit, instead of RawGithub.

2) Use the CDN, which is made for production use cases and does not have a throttle limit. Otherwise, users will end up seeing a blacklisted screen, as can be seen here: 

http://rawgit.com/noelboss/featherlight/master/release/featherlight.min.js
