### PR TITLE
Call chain _super on beforeOpen in gallery plugin

### DIFF
--- a/src/featherlight.gallery.js
+++ b/src/featherlight.gallery.js
@@ -46,6 +46,7 @@
 							.append(self.createNavigation('previous'))
 							.append(self.createNavigation('next'));
 					}
+					return _super(event);
 			},
 			onKeyDown: function(_super, event){
 				var dir = {


### PR DESCRIPTION
If trying to use the gallery plugin beforeOpen is not working as gallery doesn't call the _super.
