### PR TITLE
Add responsive styling for iframes

### DIFF
--- a/src/featherlight.css
+++ b/src/featherlight.css
@@ -103,7 +103,6 @@
 		width: 100%;
 	}
 
-
 	.featherlight-iframe .featherlight-content {
 		/* removed the border for image croping since iframe is edge to edge */
 		border-bottom: 0;
@@ -111,8 +110,44 @@
 	}
 
 	.featherlight iframe {
+		/* position */
+		position: absolute;
+
+		/* dimensions */
+		width: 100%;
+		height: 100%;
+
 		/* styling */
 		border: none;
+	}
+
+	.featherlight-iframe .featherlight-content{
+		/* dimensions: 1140px prevents iframe from spanning the full width of the browser */
+		width: 100%;
+		max-width: 1140px;
+
+		/* spacing */
+		margin: 0;
+		padding: 0;
+	}
+
+	.featherlight-iframe .featherlight-inner{
+		/* positioning */
+		display: block;
+		float: left;
+		position: relative;
+
+		/* dimensions */
+		width: 100%;
+	}
+	.featherlight .featherlight-inner:after{
+		/* dimensions */
+		content: "";
+		float: left;
+		width: 100%;
+		padding-top: 57%;
+		display: block;
+		position: relative;
 	}
 }
 
@@ -126,5 +161,8 @@
 
 		padding: 10px 10px 0;
 		border-bottom: 10px solid transparent;
+	}
+	.featherlight-iframe .featherlight-content{
+		margin: 0;
 	}
 }


### PR DESCRIPTION
Add CSS that make iframes responsive, and helps them to scale while preserving aspect ratio. In addition a maximum width is applied to the iframe to prevent it from spanning the full width of the browser at large screen sizes.