### PR TITLE
Add afterNavigateTo method

### DIFF
--- a/src/featherlight.gallery.js
+++ b/src/featherlight.gallery.js
@@ -98,6 +98,7 @@
 		nextIcon: '&#9654;',         /* Code that is used as next icon */
 		galleryFadeIn: 100,          /* fadeIn speed when image is loaded */
 		galleryFadeOut: 300,         /* fadeOut speed before image is loaded */
+        afterNavigateTo: $.noop,     /* Called after navigate to loads the slide, gets index as parameter */
 
 		slides: function() {
 			if (this.filter) {
@@ -131,7 +132,9 @@
 					self.setContent($newContent);
 					self.afterContent();
 					$newContent.fadeTo(self.galleryFadeIn,1);
-			});
+			})
+            /* Call afterNavigateTo after fadeIn is done */
+            .done(function(){ self.afterNavigateTo(index); });
 		},
 
 		createNavigation: function(target) {


### PR DESCRIPTION
I suggest adding an afterNavigateTo method. I found it really helpful when adding small thumbnails as an additional way to navigate within a given slideshow. Here's an example of how I used it:

```
$(this).featherlightGallery({
    filter: '.gallery-slideshow > a',
    variant: 'gallery-slideshow',
    afterContent: function() {
        var $slideshow = this,
            $gallery = $(this.$currentTarget).parents('.gallery-slideshow'),
            $thumbs = $('> a', $gallery),
            $navigation = $('<div>', {class:'navigation'});
        $thumbs.each(function(){
            var $thumb = $('<a>', {href:'#'});
            $thumb.on('click', function(e){
                e.preventDefault();
                $slideshow.navigateTo($(this).index());
            });
            $navigation.append($thumb);
        });
        $('a:eq(0)', $navigation).addClass('active');
        // Attach
        this.$content.after($navigation)
    },
    afterNavigateTo: function(index){
        var $navigation = $('.navigation', this.$content.parent()),
            $thumb = $('> a:eq('+index+')', $navigation);
        $thumb.addClass('active');
        $thumb.siblings().removeClass('active');
    }
});
```

So now, when you click on the mini thumbnails, they will navigate to the proper slide and get the class *active* assigned to them.