### PR TITLE
Feature/145 add to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
 		"slim",
 		"small",
 		"ui",
-		"window"
+		"window",
+		"jquery-plugin",
+		"ecosystem:jquery"
 	],
 	"licenses": [
 		{


### PR DESCRIPTION
This PR is related to #145. I haven't yet published featherlight to `npm`. This should be done by a maintainer, don't you think?

What i've done so far:

1. added specific keywords (as suggested by npm) to `package.json`
2. ~~added a grunt task to automatically publish featherlight after `grunt:bump`~~

I excluded the grunt task `test-release`, simply because i've no idea what this task is used to. Please enlighten me :)
