### PR TITLE
feat(gallery): include hidden navigation buttons on touch aware devices

### DIFF
--- a/src/featherlight.gallery.css
+++ b/src/featherlight.gallery.css
@@ -71,6 +71,11 @@
 		display: inline-block;
 	}
 
+	.featherlight-swipe-aware .featherlight-next,
+	.featherlight-swipe-aware .featherlight-previous {
+		display: none;
+	}
+
 	/* Hide navigation while loading */
 	.featherlight-loading .featherlight-previous, .featherlight-loading .featherlight-next {
 		display:none;

--- a/src/featherlight.gallery.js
+++ b/src/featherlight.gallery.js
@@ -56,11 +56,15 @@
 						self._swiper = swipeAwareConstructor(self.$instance)
 							.on('swipeleft', self._swipeleft = function()  { self.$instance.trigger('next'); })
 							.on('swiperight', self._swiperight = function() { self.$instance.trigger('previous'); });
-					} else {
-						self.$instance.find('.'+self.namespace+'-content')
-							.append(self.createNavigation('previous'))
-							.append(self.createNavigation('next'));
+
+						self.$instance
+							.addClass(this.namespace+'-swipe-aware', swipeAwareConstructor);
 					}
+
+					self.$instance.find('.'+self.namespace+'-content')
+						.append(self.createNavigation('previous'))
+						.append(self.createNavigation('next'));
+
 					return _super(event);
 			},
 			beforeContent: function(_super, event) {


### PR DESCRIPTION
This was discussed in #210 

I have implemented the feature to always include navigation buttons in the markup.
On touch aware devices the lightbox instance will have a css class `featherlight-swipe-aware`.
The default styles will then hide the navigation buttons to stay backward compatible.

You can then choose to override the default and display navigation buttons with:

``` css
.featherlight-swipe-aware .featherlight-next,
.featherlight-swipe-aware .featherlight-previous {
  display: inline-block;
}
```
