### PR TITLE
Fix/iframe attributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 2

--- a/index.html
+++ b/index.html
@@ -74,7 +74,8 @@
 					<a class="btn btn-default" href="#" data-featherlight="#fl1">Default</a>
 					<a class="btn btn-default" href="#" data-featherlight="#fl2" data-featherlight-variant="fixwidth">Custom Styles</a>
 					<a class="btn btn-default" href="assets/images/droplets.jpg" data-featherlight="image">Image</a>
-					<a class="btn btn-default" href="#" data-featherlight="#fl3">iFrame</a>
+					<a class="btn btn-default" href="https://player.vimeo.com/video/33110953" data-featherlight="iframe" data-featherlight-iframe-allowfullscreen="true" data-featherlight-iframe-width="500" data-featherlight-iframe-height="281">iFrame</a>
+
 					<a class="btn btn-default" href="index.html .ajaxcontent" data-featherlight="ajax">Ajax</a>
 				</div>
 			</div>
@@ -154,8 +155,6 @@
 			<p>It's easy to override the styling of Featherlight. All you need to do is specify an additional class in the data-featherlight-variant of the triggering element. This class will be added and you can then override everything. You can also reset all CSS: <em>$('.special').featherlight({ resetCss: true });</em>
 			</p>
 		</div>
-
-		<iframe class="lightbox" src="//player.vimeo.com/video/33110953" width="500" height="281" id="fl3" style="border:none;" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 		<div class="ajaxcontent lightbox">
 			<h2>This Ligthbox was loaded using ajax</h2>

--- a/package.json
+++ b/package.json
@@ -62,5 +62,9 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/noelboss/featherlight.git"
+	},
+	"scripts": {
+		"build": "grunt",
+		"test": "grunt test"
 	}
 }

--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -66,31 +66,31 @@
 					'sandbox', 'src', 'srcdoc', 'width'],
 				attrs = {};
 
-			whiteList.map(function(item) {
+			$.each(whiteList, function(index, item) {
 				var attrValue = parseAttrs(obj, 'iframe')[item];
 
 				if (attrValue) {
 					attrs[item] = attrValue;
 					return attrs[item];
-			 	}
+				}
 			});
 
 			return attrs;
 		}
 	};
 
-function parseAttrs(obj, prefix) {
-	var attrs = {},
-		regex = new RegExp('^' + prefix + '([A-Z])(.*)');
-	for (var key in obj) {
-		var match = key.match(regex);
-		if (match) {
-			var dasherized = (match[1] + match[2].replace(/([A-Z])/g, '-$1')).toLowerCase();
-			attrs[dasherized] = obj[key];
+	function parseAttrs(obj, prefix) {
+		var attrs = {},
+			regex = new RegExp('^' + prefix + '([A-Z])(.*)');
+		for (var key in obj) {
+			var match = key.match(regex);
+			if (match) {
+				var dasherized = (match[1] + match[2].replace(/([A-Z])/g, '-$1')).toLowerCase();
+				attrs[dasherized] = obj[key];
+			}
 		}
+		return attrs;
 	}
-	return attrs;
-}
 
 	/* document wide key handler */
 	var eventMap = { keyup: 'onKeyUp', resize: 'onResize' };

--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -54,20 +54,43 @@
 			return opened;
 		};
 
-	// structure({iframeMinHeight: 44, foo: 0}, 'iframe')
-	//   #=> {min-height: 44}
-	var structure = function(obj, prefix) {
-		var result = {},
-			regex = new RegExp('^' + prefix + '([A-Z])(.*)');
-		for (var key in obj) {
-			var match = key.match(regex);
-			if (match) {
-				var dasherized = (match[1] + match[2].replace(/([A-Z])/g, '-$1')).toLowerCase();
-				result[dasherized] = obj[key];
-			}
+	var iframeStructure = {
+		// iframeStructure.css({iframeMinHeight: 44, foo: 0}, 'iframe') => {min-height: 44}
+		css: function(obj) {
+			return parseAttrs(obj, 'iframe');
+		},
+		// NOTE: List of available [iframe attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe).
+		attr: function(obj) {
+			var whiteList = ['allowfullscreen', 'frameborder', 'height', 'longdesc',
+					'marginheight', 'marginwidth', 'name', 'referrerpolicy', 'scrolling',
+					'sandbox', 'src', 'srcdoc', 'width'],
+				attrs = {};
+
+			whiteList.map(function(item) {
+				var attrValue = parseAttrs(obj, 'iframe')[item];
+
+				if (attrValue) {
+					attrs[item] = attrValue;
+					return attrs[item];
+			 	}
+			});
+
+			return attrs;
 		}
-		return result;
 	};
+
+function parseAttrs(obj, prefix) {
+	var attrs = {},
+		regex = new RegExp('^' + prefix + '([A-Z])(.*)');
+	for (var key in obj) {
+		var match = key.match(regex);
+		if (match) {
+			var dasherized = (match[1] + match[2].replace(/([A-Z])/g, '-$1')).toLowerCase();
+			attrs[dasherized] = obj[key];
+		}
+	}
+	return attrs;
+}
 
 	/* document wide key handler */
 	var eventMap = { keyup: 'onKeyUp', resize: 'onResize' };
@@ -384,7 +407,8 @@
 					var $content = $('<iframe/>')
 						.hide()
 						.attr('src', url)
-						.css(structure(this, 'iframe'))
+						.attr(iframeStructure.attr(this))
+						.css(iframeStructure.css(this))
 						.on('load', function() { deferred.resolve($content.show()); })
 						// We can't move an <iframe> and avoid reloading it,
 						// so let's put it in place ourselves right now:

--- a/src/index.html
+++ b/src/index.html
@@ -74,7 +74,8 @@
 					<a class="btn btn-default" href="#" data-featherlight="#fl1">Default</a>
 					<a class="btn btn-default" href="#" data-featherlight="#fl2" data-featherlight-variant="fixwidth">Custom Styles</a>
 					<a class="btn btn-default" href="../assets/images/droplets.jpg" data-featherlight="image">Image</a>
-					<a class="btn btn-default" href="#" data-featherlight="#fl3">iFrame</a>
+					<a class="btn btn-default" href="https://player.vimeo.com/video/33110953" data-featherlight="iframe" data-featherlight-iframe-allowfullscreen="true" data-featherlight-iframe-width="500" data-featherlight-iframe-height="281">iFrame</a>
+
 					<a class="btn btn-default" href="index.html .ajaxcontent" data-featherlight="ajax">Ajax</a>
 				</div>
 			</div>
@@ -154,8 +155,6 @@
 			<p>It's easy to override the styling of Featherlight. All you need to do is specify an additional class in the data-featherlight-variant of the triggering element. This class will be added and you can then override everything. You can also reset all CSS: <em>$('.special').featherlight({ resetCss: true });</em>
 			</p>
 		</div>
-
-		<iframe class="lightbox" src="//player.vimeo.com/video/33110953" width="500" height="281" id="fl3" style="border:none;" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 		<div class="ajaxcontent lightbox">
 			<h2>This Ligthbox was loaded using ajax</h2>

--- a/test/featherlight_test.js
+++ b/test/featherlight_test.js
@@ -409,6 +409,27 @@ var stubAjaxLoad = function(content) {
 				expect($('.featherlight iframe')).to.have.css('width').equal('323px');
 				expect($('.featherlight iframe')).to.have.css('min-height').equal('212px');
 			});
+
+			describe('generates an iframe with tag attributes', function() {
+				it('adds `allowfullescreen` attribute', function() {
+					$('<a data-featherlight-iframe="http://www.apple.com" '+
+						'data-featherlight-iframe-allowfullscreen="true">').featherlight().click();
+
+					expect($('.featherlight iframe')).to.have.attr('src').equal('http://www.apple.com');
+					expect($('.featherlight iframe')).to.have.attr('allowfullscreen').equal('true');
+				});
+
+				it('does not add invalid attributes', function() {
+					$('<a data-featherlight-iframe="http://www.apple.com" '+
+						'data-featherlight-iframe-invalid="foo" '+
+						'data-featherlight-iframe-display="flex">').featherlight().click();
+
+					expect($('.featherlight iframe')).to.have.attr('src').equal('http://www.apple.com');
+					expect($('.featherlight iframe')).to.not.have.css('display').equal('flex');
+					expect($('.featherlight iframe')).to.not.have.attr('display').equal('flex');
+					expect($('.featherlight iframe')).to.not.have.attr('invalid').equal('foo');
+				});
+			});
 		});
 
 	});


### PR DESCRIPTION
This PR addresses the issue that other `data-featherlight-iframe-...` attributes do not get added to the iframe when it's constructed because we're limited to just [CSS attributes here](https://github.com/noelboss/featherlight/blame/34b21abfecb2f913f0dd432b772d6a9ab532fd73/src/featherlight.js#L353).