### PR TITLE
Fix IE/Edge specific error

### DIFF
--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -573,7 +573,9 @@
 
 				this._$previouslyWithTabIndex.add(this._$previouslyTabbable).attr('tabindex', -1);
 
-				document.activeElement.blur();
+				if (typeof document.activeElement.blur !== 'undefined') {
+					document.activeElement.blur();
+				}
 				return _super(event);
 			},
 


### PR DESCRIPTION
Makes sure element (for example <svg>) supports the .blur() method before calling it.