### PR TITLE
Takes padding and border into account for content size calculations

### DIFF
--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -330,7 +330,10 @@
 				/* Resize content */
 				if (ratio > 1) {
 					ratio = h / Math.floor(h / ratio); /* Round ratio down so height calc works */
-					this.$content.css('width', '' + w / ratio + 'px').css('height', '' + h / ratio + 'px');
+					var paddingW = this.$content.parent().outerWidth() - this.$content.parent().width();
+					var paddingH = this.$content.parent().outerHeight() - this.$content.parent().height();
+					
+					this.$content.css('width', '' + w / ratio - paddingW + 'px').css('height', '' + h / ratio - paddingH  + 'px');
 				}
 			}
 		},

--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -325,15 +325,12 @@
 				/* Calculate the worst ratio so that dimensions fit */
 				 /* Note: -1 to avoid rounding errors */
 				var ratio = Math.max(
-					w  / (parseInt(this.$content.parent().css('width'),10)-1),
-					h / (parseInt(this.$content.parent().css('height'),10)-1));
+					w  / (this.$content.parent().width()-1),
+					h / (this.$content.parent().height()-1));
 				/* Resize content */
 				if (ratio > 1) {
 					ratio = h / Math.floor(h / ratio); /* Round ratio down so height calc works */
-					var paddingW = this.$content.parent().outerWidth() - this.$content.parent().width();
-					var paddingH = this.$content.parent().outerHeight() - this.$content.parent().height();
-					
-					this.$content.css('width', '' + w / ratio - paddingW + 'px').css('height', '' + h / ratio - paddingH  + 'px');
+					this.$content.css('width', '' + w / ratio + 'px').css('height', '' + h / ratio + 'px');
 				}
 			}
 		},


### PR DESCRIPTION
This fixes an issue where you would get a vertical scrollbar if your viewport has less height then the image.

You can see it for yourself : [jsfiddle.net/aoejbz8s/9/](url) just adjust the viewport so it is smaller then the image.

As stated in https://github.com/noelboss/featherlight/issues/43 after it was closed, the calculation for big images was still missing the inclusion of padding+border
This issue is also discussed here : https://stackoverflow.com/questions/32148937/featherlight-js-large-images-still-scrolling
