### PR TITLE
Disable scrolling on mobile devices [#273]

### DIFF
--- a/src/featherlight.css
+++ b/src/featherlight.css
@@ -11,6 +11,13 @@
 		overflow: hidden;
 	}
 
+	html.with-featherlight body {
+		/* disable global scrolling in a cross-browser and device-compliant way */
+		position: fixed;
+		width: 100%; /* Ensure page width is unaffected by fixed position. */
+		height: initial; /* Because height of 100% will break iOS. */
+	}
+
 	.featherlight {
 		display: none;
 
@@ -70,6 +77,9 @@
 
 		/* reset white-space wrapping */
 		white-space: normal;
+
+		/* Improve scroll experience for ios users on long featherlights. */
+		-webkit-overflow-scrolling: touch;
 	}
 
 	/* contains the content */

--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -560,8 +560,11 @@
 			},
 
 			beforeOpen: function(_super, event) {
-				// Used to disable scrolling
+				// Disable scrolling in a cross-browser and device-compliant way.
 				$(document.documentElement).addClass('with-featherlight');
+				$(document.body).css({
+					'top': '-' + $(document.body).scrollTop() + 'px'
+				});
 
 				// Remember focus:
 				this._previouslyActive = document.activeElement;
@@ -594,9 +597,14 @@
 					$(elem).attr('tabindex', self._previousWithTabIndices[i]);
 				});
 				this._previouslyActive.focus();
-				// Restore scroll
+				// Restore scroll and reset viewport to the original scroll position.
 				if(Featherlight.opened().length === 0) {
 					$(document.documentElement).removeClass('with-featherlight');
+					var scroll = Math.abs(parseInt($(document.body).css('top')));
+					$(document.body).css({
+						'top': ''
+					});
+					window.scrollTo(0, scroll);
 				}
 				return r;
 			},


### PR DESCRIPTION
PR to add proper cross-browser and device-compatible approach to restricting viewport / page background scroll while a featherlight is open.