### PR TITLE
Fixed the gallery + close anywhere bug

### DIFF
--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -170,8 +170,9 @@
 			/* close when click on background/anywhere/null or closebox */
 			self.$instance.on(self.closeTrigger+'.'+self.namespace, function(event) {
 				var $target = $(event.target);
-				if( ('background' === self.closeOnClick  && $target.is('.'+self.namespace))
-					|| 'anywhere' === self.closeOnClick
+				var eclass = $target.attr('class');
+				if	( ('background' === self.closeOnClick  && $target.is('.'+self.namespace))
+					|| ('anywhere' === self.closeOnClick && eclass!=='featherlight-previous' && eclass!=='featherlight-next' && eclass!==undefined)
 					|| $target.closest(closeButtonSelector).length ){
 					self.close(event);
 					event.preventDefault();


### PR DESCRIPTION
there was a bug when someone tried to use `$.featherlight.defaults.closeOnClick = 'anywhere';` + gallery 

fixed it by checking the event target however sometimes the `featherlight-next` returns undefined i'm checking for undefined and everything is working however it'd be good if someone could fix this undefined problem

everything is working however the undefined is pissing me off