### PR TITLE
Fix 3 issues (Unnecessary scrollbar on iFrames, Missing attributes for iFrame, Update readme with examples of videos in iFrame)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,8 +352,9 @@ The default size of the iframe is very small (300 x 150).
 
 Options:  
 You can use the following iframe attributes:  
-
-	allow, allowfullscreen, frameborder, height, longdesc, marginheight, marginwidth, mozallowfullscreen, name, referrerpolicy, sandbox, scrolling, src, srcdoc, style, webkitallowfullscreen, width  
+`
+allow, allowfullscreen, frameborder, height, longdesc, marginheight, marginwidth, mozallowfullscreen, name, referrerpolicy, sandbox, scrolling, src, srcdoc, style, webkitallowfullscreen, width  
+`  
 
 For example, to set the height and width, you would use
 
@@ -371,26 +372,24 @@ You can also set the iframe attributes `iframeWidth`, `iframeMinWidth` etc. usin
 ## Open YouTube video with Featherlight
 Featherlight generates an iframe that contains the embedded video.
 
-Display a clickable thumbnail image that opens a video with a fixed size of 640 x 480 and automatically start playback:
-```
+Display a clickable thumbnail image that opens a video with a fixed size of 640 x 480 and automatically start playback:  
+`
 <a href="http://www.youtube.com/embed/f0BzD1zCye0?rel=0&amp;autoplay=1" data-featherlight="iframe" data-featherlight-iframe-width="640" data-featherlight-iframe-height="480" data-featherlight-iframe-frameborder="0" data-featherlight-iframe-allow="autoplay; encrypted-media" data-featherlight-iframe-allowfullscreen="true">
 <img src="http://img.youtube.com/vi/f0BzD1zCye0/0.jpg" alt="" />
 </a>
-```
-A text link that opens a video in a lightbox that is stretched to 85% height and width of the viewport:
-```
-<a href="http://www.youtube.com/embed/f0BzD1zCye0?rel=0&amp;autoplay=1" data-featherlight="iframe" data-featherlight-iframe-frameborder="0" data-featherlight-iframe-allow="autoplay; encrypted-media" data-featherlight-iframe-allowfullscreen="true" data-featherlight-iframe-style="display:block;border:none;height:85vh;width:85vw;">
-<img src="http://img.youtube.com/vi/f0BzD1zCye0/0.jpg" alt="" />
-</a>
-```
+`  
+
+A text link that opens a video in a lightbox that is stretched to 85% height and width of the viewport:  
+`
+<a href="http://www.youtube.com/embed/f0BzD1zCye0?rel=0&amp;autoplay=1" data-featherlight="iframe" data-featherlight-iframe-frameborder="0" data-featherlight-iframe-allow="autoplay; encrypted-media" data-featherlight-iframe-allowfullscreen="true" data-featherlight-iframe-style="display:block;border:none;height:85vh;width:85vw;">My video</a>
+`  
+
 A link that opens a video in a lightbox that fills 100% of the window:  
-Note: the "close" icon is not visible so this example is not user-friendly.
-```
+Note: the "close" icon is not visible so this example is not user-friendly.  
+`
 <a href="http://www.youtube.com/embed/f0BzD1zCye0?rel=0&amp;autoplay=1" data-featherlight="iframe" data-featherlight-iframe-frameborder="0" data-featherlight-iframe-allow="autoplay; encrypted-media" data-featherlight-iframe-allowfullscreen="true" 
-data-featherlight-iframe-style="position:fixed;background:#000;border:none;top:0;right:0;bottom:0;left:0;width:100%;height:100%;">
-<img src="http://img.youtube.com/vi/f0BzD1zCye0/0.jpg" alt=""  />
-</a>
-```
+data-featherlight-iframe-style="position:fixed;background:#000;border:none;top:0;right:0;bottom:0;left:0;width:100%;height:100%;">My video</a>
+`
 
 # IE8 background transparency
 If you want the background in IE8 to be translucent, use data:image before the rgba background:

--- a/README.md
+++ b/README.md
@@ -345,14 +345,52 @@ or you can provide the link directly as the featherlight-attribute:
 	<a href="#" data-featherlight="url.html .jQuery-Selector">Open Ajax Content</a>
 
 ## Open lightbox with iframe
-Featherlight generates an iframe with the 'iframe' keyword and a given url
+Featherlight generates an iframe with the 'iframe' keyword and a given URL.  
+The default size of the iframe is very small (300 x 150).  
 
 	<a href="http://www.example.com" data-featherlight="iframe">Open example.com in an iframe</a>
 
-Options `iframeWidth`, `iframeMinWidth`, etc. or their corresponding data attributes `data-featherlight-iframe-width`, `data-featherlight-iframe-min-width` are used as CSS when present.
+Options:  
+You can use the following iframe attributes:  
+
+	allow, allowfullscreen, frameborder, height, longdesc, marginheight, marginwidth, mozallowfullscreen, name, referrerpolicy, sandbox, scrolling, src, srcdoc, style, webkitallowfullscreen, width  
+
+For example, to set the height and width, you would use
+
+	data-featherlight-iframe-height="640" data-featherlight-iframe-width="480"
+
+or to set some css style:
+
+	data-featherlight-iframe-style="border:none"
+
+You can also set the iframe attributes `iframeWidth`, `iframeMinWidth` etc. using JavaScript:
 
 	$.featherlight({iframe: 'editor.html', iframeMaxWidth: '80%', iframeWidth: 500,
 		iframeHeight: 300});
+
+## Open YouTube video with Featherlight
+Featherlight generates an iframe that contains the embedded video.
+
+Display a clickable thumbnail image that opens a video with a fixed size of 640 x 480 and automatically start playback:
+```
+<a href="http://www.youtube.com/embed/f0BzD1zCye0?rel=0&amp;autoplay=1" data-featherlight="iframe" data-featherlight-iframe-width="640" data-featherlight-iframe-height="480" data-featherlight-iframe-frameborder="0" data-featherlight-iframe-allow="autoplay; encrypted-media" data-featherlight-iframe-allowfullscreen="true">
+<img src="http://img.youtube.com/vi/f0BzD1zCye0/0.jpg" alt="" />
+</a>
+```
+A text link that opens a video in a lightbox that is stretched to 85% height and width of the viewport:
+```
+<a href="http://www.youtube.com/embed/f0BzD1zCye0?rel=0&amp;autoplay=1" data-featherlight="iframe" data-featherlight-iframe-frameborder="0" data-featherlight-iframe-allow="autoplay; encrypted-media" data-featherlight-iframe-allowfullscreen="true" data-featherlight-iframe-style="display:block;border:none;height:85vh;width:85vw;">
+<img src="http://img.youtube.com/vi/f0BzD1zCye0/0.jpg" alt="" />
+</a>
+```
+A link that opens a video in a lightbox that fills 100% of the window:  
+Note: the "close" icon is not visible so this example is not user-friendly.
+```
+<a href="http://www.youtube.com/embed/f0BzD1zCye0?rel=0&amp;autoplay=1" data-featherlight="iframe" data-featherlight-iframe-frameborder="0" data-featherlight-iframe-allow="autoplay; encrypted-media" data-featherlight-iframe-allowfullscreen="true" 
+data-featherlight-iframe-style="position:fixed;background:#000;border:none;top:0;right:0;bottom:0;left:0;width:100%;height:100%;">
+<img src="http://img.youtube.com/vi/f0BzD1zCye0/0.jpg" alt=""  />
+</a>
+```
 
 # IE8 background transparency
 If you want the background in IE8 to be translucent, use data:image before the rgba background:

--- a/src/featherlight.css
+++ b/src/featherlight.css
@@ -124,7 +124,6 @@ html.with-featherlight {
 	border-bottom: 0;
 	padding: 0;
 	-webkit-overflow-scrolling: touch;
-	overflow-y: scroll;
 }
 
 .featherlight iframe {

--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -71,8 +71,9 @@
 
 	// NOTE: List of available [iframe attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe).
 	var iFrameAttributeSet = {
-		allowfullscreen: 1, frameborder: 1, height: 1, longdesc: 1, marginheight: 1, marginwidth: 1,
-		name: 1, referrerpolicy: 1, scrolling: 1, sandbox: 1, src: 1, srcdoc: 1, width: 1
+		allow: 1, allowfullscreen: 1, frameborder: 1, height: 1, longdesc: 1, marginheight: 1, marginwidth: 1,
+		mozallowfullscreen: 1, name: 1, referrerpolicy: 1, sandbox: 1, scrolling: 1, src: 1, srcdoc: 1, style: 1,
+		webkitallowfullscreen: 1, width: 1
 	};
 
 	// Converts camelCased attributes to dasherized versions for given prefix:


### PR DESCRIPTION
This PR addresses 3 issues.  
The functionality was tested on Chrome & Firefox on Ubuntu, and Chrome on Android.

### 1.
Unnecessary scrollbar on iFrames.

**Related issues:**  
https://github.com/noelboss/featherlight/issues/305

**Solution:**  
The `overflow-y` attribute for iFrame should be removed (or set to 'auto').

.

### 2.
Missing attributes for iFrame: `style`, `allow`, etc.

**Related issues:**  
https://github.com/noelboss/featherlight/pull/269

**Solution:**  
Add support for the following iFrame attributes:  
`data-featherlight-iframe-style`  
`data-featherlight-iframe-allow`  
`data-featherlight-iframe-webkitallowfullscreen`  
`data-featherlight-iframe-mozallowfullscreen`  


These are useful for embedding videos.  
e.g.  
`
<a href="http://www.youtube.com/embed/f0BzD1zCye0?rel=0&amp;autoplay=1" data-featherlight="iframe" data-featherlight-iframe-frameborder="0" data-featherlight-iframe-allow="autoplay; encrypted-media" data-featherlight-iframe-allowfullscreen="true" data-featherlight-iframe-style="display:block;border:none;height:85vh;width:85vw;">
`

.

### 3.
Add some examples to README for creating an iFrames with a YouTube video, and how to make it a fullsize window with 100% width or height.

**Related issues:**  
https://github.com/noelboss/featherlight/issues/301
https://github.com/noelboss/featherlight/issues/188
https://github.com/noelboss/featherlight/issues/104

**Solution:**  
I added 3 examples to the README.  
There are many ways to achieve this but it took me a long time to find a method that actually worked, a method that didn't hide Featherlight's "close" icon, and a method that could be set using the style tag.

.