### PR TITLE
reject when `load` has an "error" status

### DIFF
--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -282,9 +282,11 @@
 
 					/* Set content and show */
 					return $.when($content)
-						.always(function($content){
-							self.setContent($content);
-							self.afterContent(event);
+						.always(function($openendContent){
+							if($openendContent) {
+								self.setContent($openendContent);
+								self.afterContent(event);
+							}
 						})
 						.then(self.$instance.promise())
 						/* Call afterOpen after fadeIn is done */
@@ -395,7 +397,7 @@
 						if ( status !== "error" ) {
 							deferred.resolve($container.contents());
 						}
-						deferred.fail();
+						deferred.reject();
 					});
 					return deferred.promise();
 				}

--- a/test/featherlight_test.js
+++ b/test/featherlight_test.js
@@ -282,6 +282,18 @@ var stubAjaxLoad = function(content) {
 				});
 			});
 
+			it('can recover from an ajax load error, like a 404', function(done) {
+				var modal = new $.featherlight({ajax: 'bad-url-not-found.html'});
+				var p = modal.open();
+				var callbackCalled = false;
+				p.fail(function() {
+					callbackCalled = true;
+				})
+				patiently(done, function() {
+					expect(callbackCalled).to.be.true;
+				});
+			});
+
 			it('ajax content can be text only', function(done) {
 				stubAjaxLoad('Hello <b>world</b>');
 				$.featherlight({ajax: 'stubbed'});


### PR DESCRIPTION
Fix for #360 to allow for a callback to be registered with the promise to handle
errors like a 404. Without calling reject, the promise is always in a
pending state.