### PR TITLE
Set lower z-index for main element

### DIFF
--- a/src/featherlight.css
+++ b/src/featherlight.css
@@ -17,7 +17,7 @@ html.with-featherlight {
 	/* dimensions: spanning the background from edge to edge */
 	position:fixed;
 	top: 0; right: 0; bottom: 0; left: 0;
-	z-index: 2147483647; /* z-index needs to be >= elements on the site. */
+	z-index: 1999999999; /* z-index needs to be >= elements on the site. */
 
 	/* position: centering content */
 	text-align: center;


### PR DESCRIPTION
Google Recaptcha question area has lower z-index and is invisible at featherlight.
This commit can help some other people save some hairs.