### PR TITLE
Replace deprecated jQuery event shorthand

### DIFF
--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -526,7 +526,7 @@
 					$target.data('featherlight-persisted', fl);
 				}
 				if (elemConfig.$currentTarget.blur) {
-					elemConfig.$currentTarget.blur(); // Otherwise 'enter' key might trigger the dialog again
+					elemConfig.$currentTarget.trigger('blur'); // Otherwise 'enter' key might trigger the dialog again
 				}
 				fl.open(event);
 			};
@@ -648,7 +648,7 @@
 
 			afterContent: function(_super, event){
 				var r = _super(event);
-				this.$instance.find('[autofocus]:not([disabled])').focus();
+				this.$instance.find('[autofocus]:not([disabled])').trigger('focus');
 				this.onResize(event);
 				return r;
 			}


### PR DESCRIPTION
See https://github.com/jquery/jquery-migrate/blob/master/warnings.md

The current use of blur() and focus() trigger warnings for those of us running jquery-migrate

I noticed there is one other call to blur() and one other call to focus() but I believe those are to the vanilla JS versions of blur() and focus() not the jQuery versions so I don't think they should be changed.

FWIW, this fork fixes the jQuery Migrate warnings for me.