### PR TITLE
Extend image extension regex so that featherlight can work with WebP images

### DIFF
--- a/src/featherlight.js
+++ b/src/featherlight.js
@@ -392,7 +392,7 @@
 				process: function(elem) { return this.persist !== false ? $(elem) : $(elem).clone(true); }
 			},
 			image: {
-				regex: /\.(png|jpg|jpeg|gif|tiff?|bmp|svg)(\?\S*)?$/i,
+				regex: /\.(png|jpg|jpeg|gif|tiff?|bmp|svg|webp)(\?\S*)?$/i,
 				process: function(url)  {
 					var self = this,
 						deferred = $.Deferred(),


### PR DESCRIPTION
Extended the regex of image extensions in contentFilters with "webp" so that featherlight can also work with WebP images. This change makes it work on e.g. on a Grav CMS installation with grav-featherlight-plugin and WebP images.